### PR TITLE
Add a cookie jar

### DIFF
--- a/okta/okta.go
+++ b/okta/okta.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 
 	"golang.org/x/net/html"
@@ -125,7 +126,13 @@ func AwsSamlLogin(oktaHref string, samlHref string, oktaAuthResponse OktaAuthRes
 
 	samlUrl.RawQuery = query.Encode()
 
-	resp, _ := http.Get(samlUrl.String())
+	jar, _ := cookiejar.New(nil)
+
+	client := http.Client {
+		Jar: jar,
+	}
+
+ 	resp, _ := client.Get(samlUrl.String())
 	defer resp.Body.Close()
 
 	body, _ := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
This allows us to use Okta's 'Embed App' URL rather than the one John introspected from the Chrome dev tools