### PR TITLE
Make the installation instructions work

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tool to log in to AWS through Okta. If you want a backronym, try 'Your AWS Kre
 
 ## Usage
 
-To install yak, run `go get -u https://github.com/redbubble/yak`.
+To install yak, run `go get -u github.com/redbubble/yak`.
 
 ### Running
 


### PR DESCRIPTION
`go get` was a bit surprised when I ran it:

```
package https:/github.com/redbubble/yak: "https://" not allowed in import path
```

Removing the `https` protocol from the package makes it happy.