### PR TITLE
Add aliases to --list-roles

### DIFF
--- a/cmd/list_roles.go
+++ b/cmd/list_roles.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/redbubble/yak/cli"
 )
@@ -25,9 +26,32 @@ func listRolesCmd(cmd *cobra.Command, args []string) {
 		roles = (loginData.Roles)
 	}
 
-	fmt.Println("\nAvailable Roles:")
+	aliases, _ := getAliases()
+
+	for _, alias := range aliases {
+		fmt.Printf("    %s\n", alias)
+	}
+
 	for _, role := range roles {
 		fmt.Printf("    %s\n", role.RoleArn)
 	}
 	fmt.Println()
+}
+
+func getAliases() ([]string, error) {
+	var aliases map[string]string
+
+	err := viper.Sub("alias").Unmarshal(&aliases)
+
+	if err != nil {
+		return []string{}, err
+	}
+
+	keys := []string{}
+
+	for key, _ := range aliases {
+		keys = append(keys, key)
+	}
+
+	return keys, nil
 }

--- a/cmd/list_roles.go
+++ b/cmd/list_roles.go
@@ -12,7 +12,7 @@ import (
 func listRolesCmd(cmd *cobra.Command, args []string) {
 	roles, gotRoles := cli.GetRolesFromCache()
 
-	if gotRoles {
+	if !gotRoles {
 		loginData, err := cli.GetLoginData()
 
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,10 +30,8 @@ var rootCmd = &cobra.Command{
 
 		if viper.GetBool("list-roles") {
 			listRolesCmd(cmd, args)
-			return
 		} else if len(args) == 1 {
 			printVarsCmd(cmd, args)
-			return
 		} else {
 			shimCmd(cmd, args)
 		}


### PR DESCRIPTION
We can use this as a source of data for auto-completion, or, I suppose, manual completion.