### PR TITLE
Fix yak output

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"bufio"
 	"encoding/gob"
-	"fmt"
 	"os"
 	"time"
 
@@ -20,7 +19,6 @@ func Cache() *cache.Cache {
 		err := importCache(roleExpiryDuration)
 
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Couldn't read cache from file: %v\n", err)
 			cacheHandle = cache.New(roleExpiryDuration, roleExpiryDuration)
 		}
 	}

--- a/cmd/list_roles.go
+++ b/cmd/list_roles.go
@@ -17,7 +17,7 @@ func listRolesCmd(cmd *cobra.Command, args []string) {
 		loginData, err := cli.GetLoginData()
 
 		if err != nil {
-			fmt.Printf("%v\n", err)
+			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)
 		}
 

--- a/cmd/print_vars.go
+++ b/cmd/print_vars.go
@@ -20,7 +20,7 @@ func printVarsCmd(cmd *cobra.Command, args []string) {
 		loginData, err := cli.GetLoginData()
 
 		if err != nil {
-			fmt.Printf("%v\n", err)
+			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)
 		}
 
@@ -28,7 +28,7 @@ func printVarsCmd(cmd *cobra.Command, args []string) {
 		creds, err = cli.AssumeRole(loginData, roleName)
 
 		if err != nil {
-			fmt.Printf("%v\n", err)
+			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)
 		}
 

--- a/cmd/shim.go
+++ b/cmd/shim.go
@@ -20,7 +20,7 @@ func shimCmd(cmd *cobra.Command, args []string) {
 		loginData, err := cli.GetLoginData()
 
 		if err != nil {
-			fmt.Printf("%v\n", err)
+			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)
 		}
 
@@ -28,7 +28,7 @@ func shimCmd(cmd *cobra.Command, args []string) {
 		creds, err = cli.AssumeRole(loginData, roleName)
 
 		if err != nil {
-			fmt.Printf("%v\n", err)
+			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
Previously, we were outputting a lot of junk to stdout. This moves a lot of it to stderr, and removes an unnecessary line from the cache library.