### PR TITLE
Make dev builds obvious.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 VERSION ?= 1.1.3
+GIT_HASH = $(shell git rev-parse --short HEAD)
 
 .PHONY: vendor test install
 
@@ -12,7 +13,7 @@ fmt:
 	go fmt ./...
 
 install:
-	go install -ldflags "-X main.version=${VERSION}"
+	go install -ldflags "-X main.version=${VERSION}-${GIT_HASH}-dev"
 
 release:
 	git tag -a "v${VERSION}" -m "Releasing version ${VERSION}"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,7 +80,7 @@ func init() {
 }
 
 func versionCmd() {
-	fmt.Println(viper.GetString("yak.version"))
+	fmt.Printf("yak v%s\n", viper.GetString("yak.version"))
 }
 
 func initCache() {


### PR DESCRIPTION
Because goreleaser sets the version string differently anyway (from
Git tags and not from the `$VERSION` variable) it's misleading to use
only the variable here, IMHO.  This makes development builds be
clearly marked as such, plus the Git commit hash they were built from.