### PR TITLE
Serve APT from a better DNS name. Non-SSL.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ release:
 	git tag -a "v${VERSION}" -m "Releasing version ${VERSION}"
 	git push --tags
 	goreleaser --rm-dist
-	deb-s3 upload --s3-region=ap-southeast-2 --bucket=redbubble-deb-repository --sign=${DELIVERY_ENGINEERING_GPG_KEY} bin/yak_${VERSION}_linux_amd64.deb
+	deb-s3 upload --s3-region=ap-southeast-2 --bucket=apt.redbubble.com --sign=${DELIVERY_ENGINEERING_GPG_KEY} bin/yak_${VERSION}_linux_amd64.deb

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ should be usable next time you reload your shell config.
 running:
 
 ```sh
-sudo apt install apt-transport-https curl gnupg2
+sudo apt install curl gnupg2
 # This is the Redbubble GPG key, to verify releases:
-curl https://redbubble-deb-repository.s3-ap-southeast-2.amazonaws.com/delivery-engineers.pub.asc | sudo apt-key add -
-echo "deb https://redbubble-deb-repository.s3-ap-southeast-2.amazonaws.com/ stable main" > /etc/apt/sources.list.d/yak.list
+curl https://raw.githubusercontent.com/redbubble/yak/master/static/delivery-engineers.pub.asc | sudo apt-key add -
+echo "deb http://apt.redbubble.com/ stable main" > /etc/apt/sources.list.d/yak.list
 sudo apt update
 sudo apt install yak
 ```


### PR DESCRIPTION
Too lazy to make CloudFront and SSL and such work; compromise.