### PR TITLE
Explicitly tell zsh we can have a `--`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ yak --list-roles
 
 `yak` will print a list of available roles and exit.
 
+Note that if you want to pass -/-- flags to subcommands, you'll need to put a '--' before the <role> to let `yak` know
+you're done passing flags to *it*, like this:
+
+```
+yak [flags] -- <role> <command --with-flags>
+```
+
 #### Arguments
 
 ```
@@ -95,6 +102,7 @@ yak --list-roles
       --okta-domain string              The domain to use for requests to Okta
   -u, --okta-username string            Your Okta username
       --version                         Print the current version and exit
+      --                                Terminator for -/-- flags. Necessary if you want to pass -/-- flags to subcommands
 ```
 
 ### Configuring

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "yak [flags] [--list-roles | <role> [<subcommand...>]]",
+	Use:   "yak [flags] [--list-roles | [--] <role> [<subcommand...>]]",
 	Short: "A shim to do stuff with AWS credentials using Okta",
 	Long: `A shim to do stuff with AWS credentials using Okta
 
@@ -27,7 +27,10 @@ var rootCmd = &cobra.Command{
 
   * If <subcommand> is set, yak will attempt to execute it with the
     AWS keys injected into the environment.  Otherwise, the
-    credentials will conveniently be printed stdout.`,
+    credentials will conveniently be printed stdout.
+
+    Note that if you want to pass -/-- flags to your <subcommand>,
+    you'll need to put a '--' separator before the <role> so yak`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/static/completions/yak.zsh
+++ b/static/completions/yak.zsh
@@ -15,6 +15,7 @@ function _yak {
                '--no-cache[Ignore cache for this request. Mutually exclusive with --cache-only]' \
                '--cache-only[Only use cache, do not make external requests. Mutually exclusive with --no-cache]' \
                '--version[Print the current version and exit]' \
+               '--[Terminator for -- flags - necessary if you'd like to pass -/-- flags to subcommands]' \
                '1:environment:(${roles})' '*::arguments: _yak_command'
 }
 


### PR DESCRIPTION
Also add some info to the readme and helptext about how to use `yak` with flags

fixes #36  _sort of_. `yak <role> -- <command>` will still break completion, but `yak -- <role> <command>` works now. I can't find a good way to make zsh let us put the `--` in the middle of the command.