### PR TITLE
Okta Password can be stored in configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ aws_saml_endpoint = "/home/<okta_app_name>/<generic_id>/<app_id>"
 
 # Optional. Your okta username.
 username = "<my_okta_username>"
+
+# Optional. Your okta password.
+password = "<my_okta_password>"
 ```
 
 ##### How to find your config values

--- a/cli/login.go
+++ b/cli/login.go
@@ -63,14 +63,17 @@ func GetLoginData() (saml.LoginData, error) {
 		}
 
 		username := viper.GetString("okta.username")
+		password := viper.GetString("okta.password")
 
 		if username == "" {
 			fmt.Fprint(os.Stderr, "username: ")
 			username, _ = getLine()
 		}
 
-		fmt.Fprint(os.Stderr, "password: ")
-		password, _ := getPassword()
+		if password == "" {
+			fmt.Fprint(os.Stderr, "password: ")
+			password, _ = getPassword()
+		}
 
 		authResponse, err := okta.Authenticate(viper.GetString("okta.domain"), okta.UserData{username, password})
 


### PR DESCRIPTION
May be a contentious feature: Allow the Okta password to be stored in the Yak config file.

```
[okta]
username = "yak.shaver@example.com"
password = "i promise this config file is stored on an encrypted filesystem"
```
