### PR TITLE
Make credential prompts clearer

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -143,11 +143,11 @@ func promptLogin() (okta.OktaAuthResponse, error) {
 		username := viper.GetString("okta.username")
 
 		if username == "" {
-			fmt.Fprint(os.Stderr, "username: ")
+			fmt.Fprint(os.Stderr, "Okta username: ")
 			username, _ = getLine()
 		}
 
-		fmt.Fprint(os.Stderr, "password: ")
+		fmt.Fprint(os.Stderr, "Okta password: ")
 		password, _ := getPassword()
 
 		authResponse, err = okta.Authenticate(viper.GetString("okta.domain"), okta.UserData{username, password})


### PR DESCRIPTION
Sometimes it's not obvious which username and password the user should enter. For example, when `yak` gets called from a script, instead of the user executing it directly from bash.