### PR TITLE
More Portable Reading Lines

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -285,9 +285,8 @@ func getPassword() (string, error) {
 }
 
 func getLine() (string, error) {
-	reader := bufio.NewReader(os.Stdin)
-	input, err := reader.ReadString('\n')
-	input = strings.Replace(input, "\n", "", -1)
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Scan()
 
-	return input, err
+	return scanner.Text(), scanner.Err()
 }


### PR DESCRIPTION
This makes reading lines from the terminal more portable by avoiding the assumption that lines are `\n` terminated.

This has the side effect of allowing Yak to work on Windows. >.>