### PR TITLE
Fix a race condition in the ^C-terminal-state-guard code

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/signal"
 	"strconv"
 	"strings"
 	"syscall"
@@ -279,17 +278,6 @@ func CacheLoginRoles(roles []saml.LoginRole) {
 }
 
 func getPassword() (string, error) {
-	state, _ := terminal.GetState(int(syscall.Stdin))
-
-	/* This fixes an issue in bash where characters would stop echoing to the terminal at all if SIGINT was received
-     * during the password prompt */
-	channel := make(chan os.Signal, 2)
-	signal.Notify(channel, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-channel
-		terminal.Restore(int(syscall.Stdin), state)
-	}()
-
 	bytes, err := terminal.ReadPassword(int(syscall.Stdin))
 	fmt.Fprint(os.Stderr, "\n")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/redbubble/yak/format"
 )
@@ -72,11 +73,16 @@ These can be configured either in the [okta] section of ~/.config/yak/config.tom
 			}
 		}
 
+		state, stateErr := terminal.GetState(int(syscall.Stdin))
 		channel := make(chan os.Signal, 2)
 		signal.Notify(channel, os.Interrupt, syscall.SIGTERM)
 		go func() {
 			<-channel
 			fmt.Fprintln(os.Stderr, "Received termination signal, exiting...")
+			if(stateErr == nil) {
+				terminal.Restore(int(syscall.Stdin), state)
+			}
+
 			os.Exit(1)
 		}()
 


### PR DESCRIPTION
This was being caused by having multiple pieces of code catch SIGINT and SIGTERM; it was possible for the exit() to happen before the terminal was reset to its original state.