### PR TITLE
Add a login timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ your organisation's Okta administrator.
 session_duration = 3600
 ```
 
+#### Other Config
+
+```toml
+[login]
+# Optional. Duration in seconds from the start of the login process until it times out.
+timeout = 180
+```
+
 #### Aliases
 
 You can configure *role aliases* in the `[alias]` section of your config file; these can be used instead of having to

--- a/cmd/list_roles.go
+++ b/cmd/list_roles.go
@@ -13,7 +13,7 @@ func listRolesCmd(cmd *cobra.Command, args []string) error {
 	roles, gotRoles := cli.GetRolesFromCache()
 
 	if !gotRoles {
-		loginData, err := cli.GetLoginData()
+		loginData, err := cli.GetLoginDataWithTimeout()
 
 		if err != nil {
 			return err

--- a/cmd/print_credentials.go
+++ b/cmd/print_credentials.go
@@ -16,7 +16,7 @@ func printCredentialsCmd(cmd *cobra.Command, args []string) error {
 	creds := cli.AssumeRoleFromCache(roleName)
 
 	if creds == nil {
-		loginData, err := cli.GetLoginData()
+		loginData, err := cli.GetLoginDataWithTimeout()
 
 		if err != nil {
 			return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -237,6 +237,7 @@ func getConfigPath() string {
 func defaultConfigValues() {
 	viper.SetDefault("aws.session_duration", 3600)
 	viper.SetDefault("output.format", "env")
+	viper.SetDefault("login.timeout", 180)
 }
 
 func Execute() {

--- a/cmd/shim.go
+++ b/cmd/shim.go
@@ -14,7 +14,7 @@ func shimCmd(cmd *cobra.Command, args []string) error {
 	creds := cli.AssumeRoleFromCache(roleName)
 
 	if creds == nil {
-		loginData, err := cli.GetLoginData()
+		loginData, err := cli.GetLoginDataWithTimeout()
 
 		if err != nil {
 			return err


### PR DESCRIPTION
I noticed the other day that there IS actually a timeout on the SAML process - it's usually quite long, but it's definitely there. This adds a configurable timeout that defaults to three minutes, which should usually be long enough for users but still shorter than Okta.