### PR TITLE
Change author of our releases to `delivery-engineers@redbubble.com`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,8 +27,8 @@ brew:
     owner: redbubble
     name: homebrew-yak
   commit_author:
-    name: toothbrush
-    email: paul@denknerd.org
+    name: Redbubble Delivery Engineering Team
+    email: delivery-engineers@redbubble.com
 
   folder: Formula
   homepage: https://github.com/redbubble/yak


### PR DESCRIPTION
[Trello](https://trello.com/c/4qZpoKIg/3653-update-contributor-for-homebrew-repos-to-be-not-paul)