### PR TITLE
Output valid toml snippets for config suggestion

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -194,7 +194,7 @@ func chooseMFA(authResponse okta.OktaAuthResponse) (okta.AuthResponseFactor, err
 			validIndex = true
 		}
 
-		fmt.Fprintf(os.Stderr, "Set as default MFA factor by adding mfa_type = %s and mfa_provider = %s in your config!\n", factor.FactorType, factor.Provider)
+		fmt.Fprintf(os.Stderr, "Set as default MFA factor by adding mfa_type = \"%s\" and mfa_provider = \"%s\" to the [okta] section in your config!\n", factor.FactorType, factor.Provider)
 		return factor, nil
 	}
 


### PR DESCRIPTION
I tried to follow the helpful suggestion of setting up the default MFA factor in `config.toml`. It didn't work because the values were not quoted, plus I didn't know which section they need to be put in. The change I'm suggesting would make this more obvious.