### PR TITLE
Fail earlier when given a role that's neither an ARN nor an alias

### DIFF
--- a/cli/assume_role.go
+++ b/cli/assume_role.go
@@ -32,12 +32,12 @@ func AssumeRoleFromCache(role string) *sts.AssumeRoleWithSAMLOutput {
 }
 
 func ResolveRole(roleName string) (string, error) {
-	if isIamRoleArn(roleName) {
-		return roleName, nil
-	}
-
 	if viper.IsSet("alias." + roleName) {
 		return viper.GetString("alias." + roleName), nil
+	}
+
+	if isIamRoleArn(roleName) {
+		return roleName, nil
 	}
 
 	return "", fmt.Errorf(notARoleErrorMessage, roleName)

--- a/cli/assume_role.go
+++ b/cli/assume_role.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"errors"
+	"fmt"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/spf13/viper"
@@ -10,6 +12,10 @@ import (
 	"github.com/redbubble/yak/cache"
 	"github.com/redbubble/yak/saml"
 )
+
+var notARoleErrorMessage = `'%s' is neither an IAM role ARN nor a configured alias.
+
+Run 'yak --list-roles' to see which roles and aliases you can use.`
 
 func AssumeRoleFromCache(role string) *sts.AssumeRoleWithSAMLOutput {
 	if viper.GetBool("cache.no_cache") {
@@ -25,12 +31,16 @@ func AssumeRoleFromCache(role string) *sts.AssumeRoleWithSAMLOutput {
 	return &data
 }
 
-func ResolveRole(roleName string) string {
-	if viper.IsSet("alias." + roleName) {
-		return viper.GetString("alias." + roleName)
+func ResolveRole(roleName string) (string, error) {
+	if isIamRoleArn(roleName) {
+		return roleName, nil
 	}
 
-	return roleName
+	if viper.IsSet("alias." + roleName) {
+		return viper.GetString("alias." + roleName), nil
+	}
+
+	return "", fmt.Errorf(notARoleErrorMessage, roleName)
 }
 
 func AssumeRole(login saml.LoginData, desiredRole string) (*sts.AssumeRoleWithSAMLOutput, error) {
@@ -45,4 +55,10 @@ func AssumeRole(login saml.LoginData, desiredRole string) (*sts.AssumeRoleWithSA
 	}
 
 	return aws.AssumeRole(login, role, viper.GetInt64("aws.session_duration"))
+}
+
+var iamRoleArnRx = regexp.MustCompile(`^arn:aws:iam::\d*:role/[\w+=,.@-]{1,64}$`)
+
+func isIamRoleArn(roleName string) bool {
+	return iamRoleArnRx.Match([]byte(roleName))
 }

--- a/cmd/print_credentials.go
+++ b/cmd/print_credentials.go
@@ -11,7 +11,11 @@ import (
 )
 
 func printCredentialsCmd(cmd *cobra.Command, args []string) error {
-	roleName := cli.ResolveRole(args[0])
+	roleName, err := cli.ResolveRole(args[0])
+
+	if err != nil {
+		return err
+	}
 
 	creds := cli.AssumeRoleFromCache(roleName)
 

--- a/cmd/shim.go
+++ b/cmd/shim.go
@@ -8,7 +8,12 @@ import (
 )
 
 func shimCmd(cmd *cobra.Command, args []string) error {
-	roleName := cli.ResolveRole(args[0])
+	roleName, err := cli.ResolveRole(args[0])
+
+	if err != nil {
+		return err
+	}
+
 	command := args[1:]
 
 	creds := cli.AssumeRoleFromCache(roleName)


### PR DESCRIPTION
This change tests the incoming role name against a regex to determine whether or not it's an ARN for an IAM role. If not, the role name is treated as an alias. This test allows us to conclude (before making API calls!) that an incoming role name is neither a role ARN nor an alias, and hence that we can't possibly assume a role with it.

This change removes the possibility of creating aliases that look like ARNs. I think that's OK, since my imagination only gives me malicious uses cases for that.