### PR TITLE
Improved command completion when using '--'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ yak --list-roles
 
 `yak` will print a list of available roles and exit.
 
-Note that if you want to pass -/-- flags to subcommands, you'll need to put a '--' before the <role> to let `yak` know
-you're done passing flags to *it*, like this:
+Note that to pass `-/--` flags to commands you want to run, you'll need to put a `--` before the
+`<command>`, to let `yak` know you're done passing flags to *it*, like this:
 
 ```
-yak [flags] -- <role> <command --with-flags>
+yak [flags] <role> -- <command --with-flags>
 ```
 
 #### Arguments

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ yak [flags] -- <role> <command --with-flags>
   -u, --okta-username string            Your Okta username
   -o, --output-format string            Can be set to either 'json' or 'env'. The format in which to output credential data
       --version                         Print the current version and exit
-      --                                Terminator for -/-- flags. Necessary if you want to pass -/-- flags to subcommands
+      --                                Terminator for -/-- flags. Necessary if you want to pass -/-- flags to commands
 ```
 
 #### Environment Variables

--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ Note that to pass `-/--` flags to commands you want to run, you'll need to put a
 yak [flags] <role> -- <command --with-flags>
 ```
 
+For example:
+
+```
+yak --cache-only nonprod -- npx cdk --app 'npx ts-node --prefer-ts-exts bin/my-stack.ts' list
+```
+
+
 #### Arguments
 
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,19 +20,19 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "yak [flags] [--list-roles | [--] <role> [<subcommand...>]]",
+	Use:   "yak [flags] [--list-roles | [--] <role> [<command...>]]",
 	Short: "A shim to do stuff with AWS credentials using Okta",
 	Long: `A shim to do stuff with AWS credentials using Okta
 
   * With --list-roles, print a list of your available AWS roles.
     Otherwise, yak will attempt to generate AWS keys for <role>.
 
-  * If <subcommand> is set, yak will attempt to execute it with the
+  * If <command> is set, yak will attempt to execute it with the
     AWS keys injected into the environment.  Otherwise, the
     credentials will conveniently be printed stdout.
 
-    Note that if you want to pass -/-- flags to your <subcommand>,
-    you'll need to put a '--' separator before the <role> so yak
+    Note that if you want to pass -/-- flags to your <command>,
+    you'll need to put a '--' separator before the <command> so yak
     knows not to interpret those arguments for itself`,
 	SilenceUsage:  true,
 	SilenceErrors: true,

--- a/static/completions/yak.zsh
+++ b/static/completions/yak.zsh
@@ -2,7 +2,8 @@
 
 function _yak {
     local roles=($(yak --list-roles --cache-only 2>/dev/null))
-    _arguments '-h[Display this help message and exit]' \
+    _arguments -S \
+               '-h[Display this help message and exit]' \
                '--help[Display this help message and exit]' \
                '-l[List available AWS roles and exit]' \
                '--list-roles[List available AWS roles and exit]' \
@@ -15,12 +16,5 @@ function _yak {
                '--no-cache[Ignore cache for this request. Mutually exclusive with --cache-only]' \
                '--cache-only[Only use cache, do not make external requests. Mutually exclusive with --no-cache]' \
                '--version[Print the current version and exit]' \
-               '--[Terminator for -- flags - necessary if you would like to pass -/-- flags to subcommands]' \
-               '1:environment:(${roles})' '*::arguments: _yak_command'
-}
-
-function _yak_command {
-    shift words
-    (( CURRENT-- ))
-    _normal
+               '1:environment:(${roles})' '*:::command:_normal'
 }


### PR DESCRIPTION
I have found that yak's completion breaks down in the following situation:

```ShellSession
$ yak env -- [TAB]
```

I expect it to expand possible executables, but instead, it completes filenames (which is just a Zsh fallback shining though, i believe).  A side-effect is that completions for commands i rely on also break:

```ShellSession
$ yak env -- aws [TAB] # Completes external commands, instead of aws-subcommands
$ yak env -- make [TAB] # Completes external commands, instead of make targets
```

This patch to the Zsh completion file does two main things:

* Enable the `-S` flag to `_arguments` as documented here:   https://zsh.sourceforge.io/Doc/Release/Completion-System.html#Completion-Functions.  Specifically,   "`-S` — Do not complete options after a ‘--’ appearing on the line, and ignore the ‘--’."

* Don't modify the `words` array ourselves; just call `_normal` completion once we've got an   environment specified in positional argument 1.  Also, use 3 instead of 2 colons for   `'*:::command...`, which according to the docs means: With three colons before the message, the   words special array and the CURRENT special parameter are modified to refer only to the normal   arguments covered by this description.

* Finally, i've removed `--` as an explicit option, because `-S` takes care of this in a nice   built-in way.

Completions now work as i expect them to, with or without the `--` between yak and the command i'm keen to run.

