### PR TITLE
Prefix errors with "yak:" 

### DIFF
--- a/cli/assume_role.go
+++ b/cli/assume_role.go
@@ -24,7 +24,7 @@ func AssumeRole(role string) (*sts.AssumeRoleWithSAMLOutput, error) {
 	if creds == nil {
 		log.Infof("Role %s not in cache", role)
 		if viper.GetBool("cache.cache_only") {
-			return nil, errors.New("Could not find credentials in cache and --cache-only specified. Exiting.")
+			return nil, errors.New("Could not find credentials in cache and --cache-only specified. Run `yak <role>` to remedy.")
 		}
 
 		loginData, err := GetLoginDataWithTimeout()

--- a/cli/login.go
+++ b/cli/login.go
@@ -144,7 +144,7 @@ func getLoginData() (saml.LoginData, error) {
 		log.Infof("Okta session not in cache or no longer valid, re-authenticating")
 
 		if viper.GetBool("cache.cache_only") {
-			return saml.LoginData{}, errors.New("Could not find credentials in cache and --cache-only specified. Exiting.")
+			return saml.LoginData{}, errors.New("Could not find credentials in cache and --cache-only specified. Run `yak <role>` to remedy.")
 		}
 
 		authResponse, err = promptLogin()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -268,7 +268,7 @@ func Execute() {
 		} else {
 			// In this case, something went wrong, but there was either no subprocess or that subprocess didn't return
 			// an error code; we should output an  error message because it's likely nothing went to stderr.
-			fmt.Fprintf(os.Stderr, "%v\n", err)
+			fmt.Fprintf(os.Stderr, "yak: %v\n", err)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
### Description

Since `yak` is a shim, a user is almost always doing `yak foo command`, but if something goes wrong, such as forgetting the `--` in `yak fruit-role banana --peeled`, it's pretty confusing to get an error like "unknown flag --peeled", if the user knows for certain `banana` can be peeled.  This small change prefixes yak's errors, so that the user knows at a glance what failed.

