### PR TITLE
docs: Update apt instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ running:
 ```sh
 sudo apt install curl gnupg2
 # This is the Redbubble GPG key, to verify releases:
-curl https://raw.githubusercontent.com/redbubble/yak/master/static/delivery-engineers.pub.asc | sudo apt-key add -
+curl -Lq https://raw.githubusercontent.com/redbubble/yak/master/static/delivery-engineers.pub.asc | sudo gpg --no-default-keyring --import --keyring gnupg-ring:/etc/apt/trusted.gpg.d/redbubble.gpg
+sudo chmod a+r /etc/apt/trusted.gpg.d/redbubble.gpg
 echo "deb http://apt.redbubble.com/ stable main" | sudo tee /etc/apt/sources.list.d/redbubble.list
 sudo apt update
 sudo apt install yak

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ running:
 sudo apt install curl gnupg2
 # This is the Redbubble GPG key, to verify releases:
 curl https://raw.githubusercontent.com/redbubble/yak/master/static/delivery-engineers.pub.asc | sudo apt-key add -
-echo "deb http://apt.redbubble.com/ stable main" | sudo tee /etc/apt/sources.list.d/yak.list
+echo "deb http://apt.redbubble.com/ stable main" | sudo tee /etc/apt/sources.list.d/redbubble.list
 sudo apt update
 sudo apt install yak
 ```


### PR DESCRIPTION
Users get a warning when following this advice.  If we want to squash it, here's the solution.